### PR TITLE
Word refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "freq"
 version = "0.1.0"
 dependencies = [
  "stopwords",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -73,6 +74,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ keywords = [
 
 [dependencies]
 stopwords = "0.1.1"
+unicode-segmentation = "1.7.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,26 +9,17 @@ struct WordStat {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use stopwords::Stopwords;
-    let stop_words_spark: HashSet<_> = stopwords::Spark::stopwords(stopwords::Language::English)
+    let stop_words: HashSet<_> = stopwords::NLTK::stopwords(stopwords::Language::English)
         .unwrap()
         .iter()
         .collect();
-    let _stop_words_nltk: HashSet<_> = stopwords::NLTK::stopwords(stopwords::Language::English)
-        .unwrap()
-        .iter()
-        .collect();
-    let stop_words_sk: HashSet<_> = stopwords::SkLearn::stopwords(stopwords::Language::English)
-        .unwrap()
-        .iter()
-        .collect();
-    let stop_words: HashSet<_> = stop_words_spark.union(&stop_words_sk).collect();
     let mut total_counter = 0u64;
     let mut word_counter = HashMap::new();
     let stdin = std::io::stdin();
     for line in stdin.lock().lines() {
         if let Ok(line) = line {
             for word in line.unicode_words() {
-                if stop_words.contains(&&word) {
+                if stop_words.contains(&word) {
                     continue;
                 }
                 total_counter += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io::prelude::*;
+use unicode_segmentation::UnicodeSegmentation;
 
 struct WordStat {
     word: String,
@@ -12,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stdin = std::io::stdin();
     for line in stdin.lock().lines() {
         if let Ok(line) = line {
-            for word in line.split_whitespace() {
+            for word in line.unicode_words() {
                 total_counter += 1;
                 word_counter
                     .entry(word.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             f.word
         );
     }
+    println!("total words = {}", total_counter);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::prelude::*;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -8,12 +8,29 @@ struct WordStat {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use stopwords::Stopwords;
+    let stop_words_spark: HashSet<_> = stopwords::Spark::stopwords(stopwords::Language::English)
+        .unwrap()
+        .iter()
+        .collect();
+    let _stop_words_nltk: HashSet<_> = stopwords::NLTK::stopwords(stopwords::Language::English)
+        .unwrap()
+        .iter()
+        .collect();
+    let stop_words_sk: HashSet<_> = stopwords::SkLearn::stopwords(stopwords::Language::English)
+        .unwrap()
+        .iter()
+        .collect();
+    let stop_words: HashSet<_> = stop_words_spark.union(&stop_words_sk).collect();
     let mut total_counter = 0u64;
     let mut word_counter = HashMap::new();
     let stdin = std::io::stdin();
     for line in stdin.lock().lines() {
         if let Ok(line) = line {
             for word in line.unicode_words() {
+                if stop_words.contains(&&word) {
+                    continue;
+                }
                 total_counter += 1;
                 word_counter
                     .entry(word.to_string())


### PR DESCRIPTION
Refined the word identification: from `split_withespace()` to `unicode_words` provided by the `unicode-segmentation`crate.

While here, adopt the `stopwords` crate to exclude stopwords from the count